### PR TITLE
Fix deprecation warning

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ class ServerlessLocalDevServerPlugin {
         usage: 'Runs a local dev server for Alexa-Skill and HTTP functions',
         lifecycleEvents: [ 'loadEnvVars', 'start' ],
         options: {
-          port: { usage: 'Port to listen on', shortcut: 'p' }
+          port: { usage: 'Port to listen on', shortcut: 'p', type:'string' }
         }
       }
     }


### PR DESCRIPTION
This pull request fixes the following deprecation warning:
```
CLI options definitions were upgraded with "type" property (which could be one of "string", "boolean", "multiple"). Below listed plugins do not predefine type for introduced options:
 - ServerlessLocalDevServerPlugin for "port"
```